### PR TITLE
Revert "Import ABC from collections.abc for Python 3.10 compatibility."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ matrix:
   include:
   - name: "Python: 2.7"
     python: "2.7"
-  - name: "Python: 3.4"
-    python: "3.4"
-  - name: "Python: 3.5"
-    python: "3.6"
   - name: "Python: 3.6"
     python: "3.6"
   - name: "Python: 3.7"

--- a/losantrest/client.py
+++ b/losantrest/client.py
@@ -26,6 +26,7 @@ SOFTWARE.
 # pylint: disable=E0401
 
 import requests
+import collections
 import sys
 from .application import Application
 from .application_api_token import ApplicationApiToken
@@ -108,12 +109,6 @@ from .losant_error import LosantError
 
 if sys.version_info[0] == 3:
     basestring = str
-
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
-
 
 class Client(object):
     """
@@ -240,7 +235,7 @@ class Client(object):
             return result
 
         map_data = None
-        if not isinstance(data, Mapping):
+        if not isinstance(data, collections.Mapping):
             map_data = []
             for idx, val in enumerate(data):
                 map_data.append([str(idx), val])

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3'
     ],
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     include_package_data=True,
     keywords=['REST', 'Losant', 'IoT'],
     test_suite='tests',

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
     include_package_data=True,
     keywords=['REST', 'Losant', 'IoT'],
     test_suite='tests',
-    install_requires=['requests>=2.13', 'chardet'],
+    install_requires=['requests>=2.13'],
     tests_require=['requests-mock>=1.9.0'],
 )

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
     include_package_data=True,
     keywords=['REST', 'Losant', 'IoT'],
     test_suite='tests',
-    install_requires=['requests>=2.13', 'charset-normalizer'],
+    install_requires=['requests>=2.13', 'chardet'],
     tests_require=['requests-mock>=1.9.0'],
 )

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3'
     ],
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(),
     include_package_data=True,
     keywords=['REST', 'Losant', 'IoT'],
     test_suite='tests',

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
     include_package_data=True,
     keywords=['REST', 'Losant', 'IoT'],
     test_suite='tests',
-    install_requires=['requests>=2.13'],
+    install_requires=['requests>=2.13', 'charset-normalizer'],
     tests_require=['requests-mock>=1.9.0'],
 )


### PR DESCRIPTION
Reverts Losant/losant-rest-python#3 because 3.10 is a beta version. We will revert this revert when it's released. 
